### PR TITLE
Support including FastQC, FastQ Screen, and RSeQC sections multiple times in one report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
     * Fix faulty column handling for the _after filtering_ Q30 rate ([#936](https://github.com/ewels/MultiQC/issues/936))
 * **FastQC**
     * When including a FastQC section multiple times in one report, the Per Base Sequence Content heatmaps now behave as you would expect.
+* **FastQ Screen**
+    * When including a FastQ Screen section multiple times in one report, the plots now behave as you would expect.
 * **HiC Explorer**
     * Fixed bug where module tries to parse QC_table.txt, a new log file in hicexplorer v2.2.
 * **LongRanger**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
     * Added handling of demultiplexing of more than 2 reads
 * **fastp**
     * Fix faulty column handling for the _after filtering_ Q30 rate ([#936](https://github.com/ewels/MultiQC/issues/936))
+* **FastQC**
+    * When including a FastQC section multiple times in one report, the Per Base Sequence Content heatmaps now behave as you would expect.
 * **HiC Explorer**
     * Fixed bug where module tries to parse QC_table.txt, a new log file in hicexplorer v2.2.
 * **LongRanger**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
     * Fixed bug where `--dirs` broke certain input files. ([#821](https://github.com/ewels/MultiQC/issues/821))
 * **RSeQC**
     * Fixed bug where Junction Saturation plot for a single sample was mislabelling the lines.
+    * When including a RSeQC section multiple times in one report, clicking Junction Saturation plot now behaves as you would expect.
 * **Samtools**
     * Utilize in-built `read_count_multiplier` functionality to plot `flagstat` results more nicely
 * **SnpEff**

--- a/multiqc/modules/fastq_screen/fastq_screen.py
+++ b/multiqc/modules/fastq_screen/fastq_screen.py
@@ -167,6 +167,10 @@ class MultiqcModule(BaseMultiqcModule):
         <script type="text/javascript">
             if (!window.fq_screen_dict) fq_screen_dict = {{}};
             fq_screen_dict[{plot_id}] = {dict};
+
+            // Backward compatible global variables
+            fq_screen_data = fq_screen_dict[{plot_id}].data;
+            fq_screen_categories = fq_screen_dict[{plot_id}].categories;
         </script>'''.format(
             plot_id=json.dumps(plot_id),
             dict=json.dumps({ 'data': data, 'categories': categories }),

--- a/multiqc/modules/fastq_screen/fastq_screen.py
+++ b/multiqc/modules/fastq_screen/fastq_screen.py
@@ -178,6 +178,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         html += '''<script type="text/javascript">
             $(function () {
+                // In case of repeated modules: #fq_screen_plot, #fq_screen_plot-1, ..
                 $(".fq_screen_plot").each(function () {
                     var plot_id = $(this).attr('id');
 

--- a/multiqc/modules/fastq_screen/fastq_screen.py
+++ b/multiqc/modules/fastq_screen/fastq_screen.py
@@ -11,6 +11,7 @@ import re
 from multiqc import config
 from multiqc.plots import bargraph
 from multiqc.modules.base_module import BaseMultiqcModule
+from multiqc.utils import report
 
 # Initialise the logger
 log = logging.getLogger(__name__)
@@ -161,37 +162,49 @@ class MultiqcModule(BaseMultiqcModule):
                     td['linkedTo'] = ':previous'
                 data.append(td)
 
-        html = '<div id="fq_screen_plot" class="hc-plot"></div> \n\
-        <script type="text/javascript"> \n\
-            fq_screen_data = {};\n\
-            fq_screen_categories = {};\n\
-            $(function () {{ \n\
-                $("#fq_screen_plot").highcharts({{ \n\
-                    chart: {{ type: "column", backgroundColor: null }}, \n\
-                    title: {{ text: "FastQ Screen Results" }}, \n\
-                    xAxis: {{ categories: fq_screen_categories }}, \n\
-                    yAxis: {{ \n\
-                        max: 100, \n\
-                        min: 0, \n\
-                        title: {{ text: "Percentage Aligned" }} \n\
-                    }}, \n\
-                    tooltip: {{ \n\
-                        formatter: function () {{ \n\
-                            return "<b>" + this.series.stackKey.replace("column","") + " - " + this.x + "</b><br/>" + \n\
-                                this.series.name + ": " + this.y + "%<br/>" + \n\
-                                "Total Alignment: " + this.point.stackTotal + "%"; \n\
-                        }}, \n\
-                    }}, \n\
-                    plotOptions: {{ \n\
-                        column: {{ \n\
-                            pointPadding: 0, \n\
-                            groupPadding: 0.02, \n\
-                            stacking: "normal" }} \n\
-                    }}, \n\
-                    series: fq_screen_data \n\
-                }}); \n\
-            }}); \n\
-        </script>'.format(json.dumps(data), json.dumps(categories))
+        plot_id = report.save_htmlid('fq_screen_plot')
+        html = '''<div id={plot_id} class="fq_screen_plot hc-plot"></div>
+        <script type="text/javascript">
+            if (!window.fq_screen_dict) fq_screen_dict = {{}};
+            fq_screen_dict[{plot_id}] = {dict};
+        </script>'''.format(
+            plot_id=json.dumps(plot_id),
+            dict=json.dumps({ 'data': data, 'categories': categories }),
+        )
+
+        html += '''<script type="text/javascript">
+            $(function () {
+                $(".fq_screen_plot").each(function () {
+                    var plot_id = $(this).attr('id');
+
+                    $(this).highcharts({
+                        chart: { type: "column", backgroundColor: null },
+                        title: { text: "FastQ Screen Results" },
+                        xAxis: { categories: fq_screen_dict[plot_id].categories },
+                        yAxis: {
+                            max: 100,
+                            min: 0,
+                            title: { text: "Percentage Aligned" }
+                        },
+                        tooltip: {
+                            formatter: function () {
+                                return "<b>" + this.series.stackKey.replace("column","") + " - " + this.x + "</b><br/>" +
+                                    this.series.name + ": " + this.y + "%<br/>" +
+                                    "Total Alignment: " + this.point.stackTotal + "%";
+                            },
+                        },
+                        plotOptions: {
+                            column: {
+                                pointPadding: 0,
+                                groupPadding: 0.02,
+                                stacking: "normal"
+                            }
+                        },
+                        series: fq_screen_dict[plot_id].data
+                    });
+                });
+            });
+        </script>'''
 
         return html
 

--- a/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
+++ b/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
@@ -6,7 +6,6 @@
 
 // Global vars
 s_height = 10;
-num_samples = 0;
 sample_names = [];
 sample_statuses = [];
 labels = [];
@@ -14,19 +13,18 @@ c_width = 0;
 c_height = 0;
 ypos = 0;
 max_bp = 0;
-current_single_plot = undefined;
 
 // Function to plot heatmap
-function fastqc_seq_content_heatmap() {
+function fastqc_seq_content_heatmap(module_element, module_key) {
 
     // Get sample names, rename and skip hidden samples
     sample_names = [];
     sample_statuses = [];
     var p_data = {};
     var hidden_samples = 0;
-    $.each(fastqc_seq_content_data, function(s_name, data){
+    $.each(fastqc_seq_content[module_key], function(s_name, data){
         // rename sample names
-        var t_status = fastqc_passfails_fastqc['per_base_sequence_content'][s_name];
+        var t_status = fastqc_passfails[module_key]['per_base_sequence_content'][s_name];
         $.each(window.mqc_rename_f_texts, function(idx, f_text){
             if(window.mqc_rename_regex_mode){
                 var re = new RegExp(f_text,'g');
@@ -54,14 +52,14 @@ function fastqc_seq_content_heatmap() {
         else { hidden_samples += 1; }
     });
     num_samples = sample_names.length;
-    $('#fastqc_seq_heatmap_div .samples-hidden-warning, #fastqc_seq_heatmap_div .fastqc-heatmap-no-samples').remove();
-    $('#fastqc_seq_heatmap_div .hc-plot-wrapper').show();
+    module_element.find('#fastqc_seq_heatmap_div .samples-hidden-warning, #fastqc_seq_heatmap_div .fastqc-heatmap-no-samples').remove();
+    module_element.find('#fastqc_seq_heatmap_div .hc-plot-wrapper').show();
     if(num_samples == 0){
-        $('#fastqc_seq_heatmap_div .hc-plot-wrapper').hide();
-        $('#fastqc_seq_heatmap_div').prepend('<p class="fastqc-heatmap-no-samples text-muted">No samples found.</p>');
+        module_element.find('#fastqc_seq_heatmap_div .hc-plot-wrapper').hide();
+        module_element.find('#fastqc_seq_heatmap_div').prepend('<p class="fastqc-heatmap-no-samples text-muted">No samples found.</p>');
     }
     if(hidden_samples > 0){
-        $('#fastqc_seq_heatmap_div').prepend('<div class="samples-hidden-warning alert alert-warning"> \
+        module_element.find('#fastqc_seq_heatmap_div').prepend('<div class="samples-hidden-warning alert alert-warning"> \
             <span class="glyphicon glyphicon-info-sign"></span> \
             <strong>Warning:</strong> '+hidden_samples+' samples hidden in toolbox. \
             <a href="#mqc_hidesamples" class="alert-link" onclick="mqc_toolbox_openclose(\'#mqc_hidesamples\', true); return false;">See toolbox.</a>\
@@ -70,21 +68,21 @@ function fastqc_seq_content_heatmap() {
     if(num_samples == 0){ return; }
 
     // Convert the CSS percentage size into pixels
-    c_width = $('#fastqc_seq_heatmap').parent().width() - 5; // -5 for status bar
-    c_height = $('#fastqc_seq_heatmap').parent().height() - 2; // -2 for bottom line padding
+    c_width = module_element.find('#fastqc_seq_heatmap').parent().width() - 5; // -5 for status bar
+    c_height = module_element.find('#fastqc_seq_heatmap').parent().height() - 2; // -2 for bottom line padding
     s_height = c_height / num_samples;
     // Minimum row height
     if(s_height < 2){
         s_height = 2;
         c_height = num_samples * 2;
-        $('#fastqc_seq_heatmap').parent().parent().height(c_height+10);
+        module_element.find('#fastqc_seq_heatmap').parent().parent().height(c_height+10);
     }
     // Resize the canvas properties
-    $('#fastqc_seq_heatmap').prop({
+    module_element.find('#fastqc_seq_heatmap').prop({
         'width': c_width,
         'height': c_height+1
     });
-    var canvas = document.getElementById('fastqc_seq_heatmap');
+    var canvas = module_element.find('#fastqc_seq_heatmap')[0];
     if (canvas && canvas.getContext) {
         var ctx = canvas.getContext('2d');
         ctx.strokeStyle = '#666666';
@@ -162,49 +160,45 @@ function fastqc_seq_content_heatmap() {
 
 // Set up listeners etc on page load
 $(function () {
+    // Go through each FastQC module in case there are multiple
+    $('.mqc-module-section[id^="mqc-module-section-fastqc"]').each(function(){
+        var module_element = $(this);
+        var module_key = module_element.attr('id').replace(/-/g, '_').replace('mqc_module_section_', '');
+        fastqc_module(module_element, module_key);
+    });
+});
 
-    // Go through each section in case FastQC is there multiple times
-    $('.mqc-module-section').each(function(i){
+function fastqc_module(module_element, module_key) {
+    // Draw sequence content heatmap
+    fastqc_seq_content_heatmap(module_element, module_key);
 
-        // Skip this module if it's not FastQC
-        if(!$(this).attr('id').startsWith('mqc-module-section-fastqc')){
-            return true;
-        }
-
-        // Add the pass / warning / fails counts to each of the FastQC submodule headings
-        var parent_id = $(this).attr('id');
-        var fastqc_passfails = window['fastqc_passfails_'+parent_id.replace(/-/g, '_').replace('mqc_module_section_', '')];
-        $.each(fastqc_passfails, function(k, vals){
-            var pid = '#'+parent_id+' [id^=fastqc_'+k+']';
-            var total = 0;
-            var v = { 'pass': 0, 'warn': 0, 'fail': 0 };
-            $.each(vals, function(s_name, status){
-                total += 1;
-                v[status] += 1;
-            });
-            var p_bar = '<div class="progress fastqc_passfail_progress"> \
-                <div class="progress-bar progress-bar-success" style="width: '+(v['pass']/total)*100+'%" title="'+v['pass']+'&nbsp;/&nbsp;'+total+' samples passed">'+v['pass']+'</div> \
-                <div class="progress-bar progress-bar-warning" style="width: '+(v['warn']/total)*100+'%" title="'+v['warn']+'&nbsp;/&nbsp;'+total+' samples with warnings">'+v['warn']+'</div> \
-                <div class="progress-bar progress-bar-danger" style="width: '+(v['fail']/total)*100+'%" title="'+v['fail']+'&nbsp;/&nbsp;'+total+' samples failed">'+v['fail']+'</div> \
-            </div>';
-            $(pid).first().append(p_bar);
+    // Add the pass / warning / fails counts to each of the FastQC submodule headings
+    $.each(fastqc_passfails[module_key], function(k, vals){
+        var total = 0;
+        var v = { 'pass': 0, 'warn': 0, 'fail': 0 };
+        $.each(vals, function(s_name, status){
+            total += 1;
+            v[status] += 1;
         });
+        var p_bar = '<div class="progress fastqc_passfail_progress"> \
+            <div class="progress-bar progress-bar-success" style="width: '+(v['pass']/total)*100+'%" title="'+v['pass']+'&nbsp;/&nbsp;'+total+' samples passed">'+v['pass']+'</div> \
+            <div class="progress-bar progress-bar-warning" style="width: '+(v['warn']/total)*100+'%" title="'+v['warn']+'&nbsp;/&nbsp;'+total+' samples with warnings">'+v['warn']+'</div> \
+            <div class="progress-bar progress-bar-danger" style="width: '+(v['fail']/total)*100+'%" title="'+v['fail']+'&nbsp;/&nbsp;'+total+' samples failed">'+v['fail']+'</div> \
+        </div>';
+        module_element.find('[id^=fastqc_'+k+']').first().append(p_bar);
     });
 
     // Create popovers on click
-    $('.fastqc_passfail_progress .progress-bar').mouseover(function(){
+    module_element.find('.fastqc_passfail_progress .progress-bar').mouseover(function(){
         // Does this element already have a popover?
         if ($(this).attr('data-original-title')) { return false; }
-        // Get data target
-        var parent_id = $(this).closest('.mqc-module-section').attr('id').replace(/-/g, '_').replace('mqc_module_section_', '');
-        var fastqc_passfails = window['fastqc_passfails_'+parent_id.replace(/-/g, '_').replace('mqc_module_section_', '')];
         // Create it
         var pid = $(this).closest('h3').attr('id');
         var k = pid.substr(7);
         // Remove suffix when there are multiple fastqc sections
         var n = k.indexOf('-');
         k = k.substring(0, n != -1 ? n : k.length);
-        var vals = fastqc_passfails[k];
+        var vals = fastqc_passfails[module_key][k];
         var passes = $(this).hasClass('progress-bar-success') ? true : false;
         var warns = $(this).hasClass('progress-bar-warning') ? true : false;
         var fails = $(this).hasClass('progress-bar-danger') ? true : false;
@@ -218,7 +212,7 @@ $(function () {
             else if(status == 'warn' && warns){ samples.push(s_name); }
             else if(status == 'fail' && fails){ samples.push(s_name); }
         });
-        $($(this)).popover({
+        $(this).popover({
             title: $(this).attr('title'),
             content: samples.sort().join('<br>'),
             html: true,
@@ -238,7 +232,7 @@ $(function () {
     });
 
     // Listener for Status higlight click
-    $('.mqc-section-fastqc .fastqc_passfail_progress').on('click', '.fastqc-status-highlight', function(e){
+    module_element.find('.fastqc_passfail_progress').on('click', '.fastqc-status-highlight', function(e){
         e.preventDefault();
         // Get sample names and highlight colour
         var samples = $(this).parent().parent().find('.popover-content').html().split('<br>');
@@ -260,7 +254,7 @@ $(function () {
     });
 
     // Listener for Status hide others click
-    $('.mqc-section-fastqc .fastqc_passfail_progress').on('click', '.fastqc-status-hideothers', function(e){
+    module_element.find('.fastqc_passfail_progress').on('click', '.fastqc-status-hideothers', function(e){
         e.preventDefault();
         // Get sample names
         var samples = $(this).parent().parent().find('.popover-content').html().split('<br>');
@@ -291,22 +285,24 @@ $(function () {
     /// SEQ CONTENT HEATMAP LISTENERS
     /////////
 
+
     // Seq Content heatmap export button
-    $('#fastqc_per_base_sequence_content_export_btn').click(function(e){
+    module_element.find('#fastqc_per_base_sequence_content_export_btn').click(function(e){
         e.preventDefault();
+        var plot_id = module_element.find('.fastqc_per_base_sequence_content_plot').attr('id');
         // Tick only this plot in the toolbox and slide out
         $('#mqc_export_selectplots input').prop('checked', false);
-        $('#mqc_export_selectplots input[value="fastqc_per_base_sequence_content_plot"]').prop('checked', true);
+        $('#mqc_export_selectplots input[value="'+plot_id+'"]').prop('checked', true);
         mqc_toolbox_openclose('#mqc_exportplots', true);
     });
 
     // Export plot
-    $('#fastqc_per_base_sequence_content_plot').on('mqc_plotexport_image', function(e, cfg){
+    module_element.find('.fastqc_per_base_sequence_content_plot').on('mqc_plotexport_image', function(e, cfg){
         alert("Apologies, it's not yet possible to export this plot.\nPlease take a screengrab or export the JSON data.");
     });
-    $('#fastqc_per_base_sequence_content_plot').on('mqc_plotexport_data', function(e, cfg){
+    module_element.find('.fastqc_per_base_sequence_content_plot').on('mqc_plotexport_data', function(e, cfg){
         if(cfg['ft'] == 'json'){
-            json_str = JSON.stringify(fastqc_seq_content_data, null, 2);
+            json_str = JSON.stringify(fastqc_seq_content[module_key], null, 2);
             var blob = new Blob([json_str], {type: "text/plain;charset=utf-8"});
             saveAs(blob, cfg['fname']);
         } else {
@@ -315,7 +311,7 @@ $(function () {
     });
 
     // Seq Content heatmap mouse rollover
-    $('#fastqc_seq_heatmap').mousemove(function(e) {
+    module_element.find('#fastqc_seq_heatmap').mousemove(function(e) {
 
         // Replace the heading above the heatmap
         var pos = findPos(this);
@@ -333,15 +329,15 @@ $(function () {
         if(s_status == 'pass'){ s_status_class = 'label-success'; }
         if(s_status == 'warn'){ s_status_class = 'label-warning'; }
         if(s_status == 'fail'){ s_status_class = 'label-danger'; }
-        $('#fastqc_per_base_sequence_content_plot_div .s_name').html('<span class="glyphicon glyphicon-info-sign"></span> ' + s_name + ' <span class="label s_status '+s_status_class+'">'+s_status+'</span>');
+        module_element.find('#fastqc_per_base_sequence_content_plot_div .s_name').html('<span class="glyphicon glyphicon-info-sign"></span> ' + s_name + ' <span class="label s_status '+s_status_class+'">'+s_status+'</span>');
 
         // Update the key with the raw data for this position
         var hover_bp = Math.max(1, Math.floor((x/c_width)*max_bp));
-        var thispoint = fastqc_seq_content_data[s_name][hover_bp];
+        var thispoint = fastqc_seq_content[module_key][s_name][hover_bp];
         if(!thispoint){
             var nearestkey = 0;
             var guessdata = null;
-            $.each(fastqc_seq_content_data[s_name], function(bp, v){
+            $.each(fastqc_seq_content[module_key][s_name], function(bp, v){
                 bp = parseInt(bp);
                 if(bp < hover_bp && bp > nearestkey){
                     nearestkey = bp;
@@ -355,37 +351,37 @@ $(function () {
                 thispoint = guessdata;
             }
         }
-        $('#fastqc_seq_heatmap_key_t span').text(thispoint['t'].toFixed(0)+'%');
-        $('#fastqc_seq_heatmap_key_c span').text(thispoint['c'].toFixed(0)+'%');
-        $('#fastqc_seq_heatmap_key_a span').text(thispoint['a'].toFixed(0)+'%');
-        $('#fastqc_seq_heatmap_key_g span').text(thispoint['g'].toFixed(0)+'%');
-        $('#fastqc_seq_heatmap_key_pos').text(thispoint['base']+' bp');
+        module_element.find('#fastqc_seq_heatmap_key_t span').text(thispoint['t'].toFixed(0)+'%');
+        module_element.find('#fastqc_seq_heatmap_key_c span').text(thispoint['c'].toFixed(0)+'%');
+        module_element.find('#fastqc_seq_heatmap_key_a span').text(thispoint['a'].toFixed(0)+'%');
+        module_element.find('#fastqc_seq_heatmap_key_g span').text(thispoint['g'].toFixed(0)+'%');
+        module_element.find('#fastqc_seq_heatmap_key_pos').text(thispoint['base']+' bp');
     });
 
     // Remove sample name again when mouse leaves
-    $('#fastqc_seq_heatmap').mouseout(function(e) {
-      $('#fastqc_per_base_sequence_content_plot_div .s_name').html('<span class="glyphicon glyphicon-info-sign"></span> Rollover for sample name');
-      $('#fastqc_seq_heatmap_key_pos').text('-');
-      $('#fastqc_seq_heatmap_key_t span').text('-');
-      $('#fastqc_seq_heatmap_key_c span').text('-');
-      $('#fastqc_seq_heatmap_key_a span').text('-');
-      $('#fastqc_seq_heatmap_key_g span').text('-');
+    module_element.find('#fastqc_seq_heatmap').mouseout(function(e) {
+        module_element.find('#fastqc_per_base_sequence_content_plot_div .s_name').html('<span class="glyphicon glyphicon-info-sign"></span> Rollover for sample name');
+        module_element.find('#fastqc_seq_heatmap_key_pos').text('-');
+        module_element.find('#fastqc_seq_heatmap_key_t span').text('-');
+        module_element.find('#fastqc_seq_heatmap_key_c span').text('-');
+        module_element.find('#fastqc_seq_heatmap_key_a span').text('-');
+        module_element.find('#fastqc_seq_heatmap_key_g span').text('-');
     });
 
     // Click sample
-    $('#fastqc_seq_heatmap').click(function(e) {
-      e.preventDefault();
-      // Get label from y position
-      var pos = findPos(this);
-      var x = e.pageX - pos.x;
-      var y = e.pageY - pos.y;
-      var idx = Math.floor(y/s_height);
-      var s_name = sample_names[idx];
-      if(s_name !== undefined){
-        plot_single_seqcontent(s_name);
-      }
+    module_element.find('#fastqc_seq_heatmap').click(function(e) {
+        e.preventDefault();
+        // Get label from y position
+        var pos = findPos(this);
+        var x = e.pageX - pos.x;
+        var y = e.pageY - pos.y;
+        var idx = Math.floor(y/s_height);
+        var s_name = sample_names[idx];
+        if(s_name !== undefined){
+            plot_single_seqcontent(s_name);
+        }
     });
-    $('#mqc-module-section-fastqc').on('click', '.fastqc_seqcontent_single_prevnext', function(e){
+    module_element.on('click', '.fastqc_seqcontent_single_prevnext', function(e){
         e.preventDefault();
         // Find next / prev sample name
         var idx = sample_names.indexOf(current_single_plot);
@@ -397,147 +393,147 @@ $(function () {
         current_single_plot = s_name;
         // Prep the new plot data
         var plot_data = [[],[],[],[]];
-        var bases = Object.keys(fastqc_seq_content_data[s_name]).sort(function (a, b) {  return a - b;  });
+        var bases = Object.keys(fastqc_seq_content[module_key][s_name]).sort(function (a, b) {  return a - b;  });
         for (i=0; i<bases.length; i++){
-          var base = fastqc_seq_content_data[s_name][bases[i]]['base'].toString().split('-');
-          base = parseFloat(base[0]);
-          plot_data[0].push([base, fastqc_seq_content_data[s_name][bases[i]]['t']]);
-          plot_data[1].push([base, fastqc_seq_content_data[s_name][bases[i]]['c']]);
-          plot_data[2].push([base, fastqc_seq_content_data[s_name][bases[i]]['a']]);
-          plot_data[3].push([base, fastqc_seq_content_data[s_name][bases[i]]['g']]);
+            var base = fastqc_seq_content[module_key][s_name][bases[i]]['base'].toString().split('-');
+            base = parseFloat(base[0]);
+            plot_data[0].push([base, fastqc_seq_content[module_key][s_name][bases[i]]['t']]);
+            plot_data[1].push([base, fastqc_seq_content[module_key][s_name][bases[i]]['c']]);
+            plot_data[2].push([base, fastqc_seq_content[module_key][s_name][bases[i]]['a']]);
+            plot_data[3].push([base, fastqc_seq_content[module_key][s_name][bases[i]]['g']]);
         }
         // Update the chart
-        var hc = $('#fastqc_sequence_content_single').highcharts();
+        var hc = module_element.find('#fastqc_sequence_content_single').highcharts();
         for (i=0; i<plot_data.length; i++){
             hc.series[i].setData(plot_data[i], false);
         }
         hc.setTitle({text: s_name});
         hc.redraw({ duration: 200 });
     });
-    $('#mqc-module-section-fastqc').on('click', '#fastqc_sequence_content_single_back', function(e){
+    module_element.on('click', '#fastqc_sequence_content_single_back', function(e){
         e.preventDefault();
-        $('#fastqc_per_base_sequence_content_plot_div').slideDown();
-        $('#fastqc_sequence_content_single_wrapper').slideUp(function(){
-          $(this).remove();
+        module_element.find('#fastqc_per_base_sequence_content_plot_div').slideDown();
+        module_element.find('#fastqc_sequence_content_single_wrapper').slideUp(function(){
+            $(this).remove();
         });
     });
 
     // Highlight the custom heatmap
     $(document).on('mqc_highlights mqc_hidesamples mqc_renamesamples mqc_plotresize', function(e){
-        fastqc_seq_content_heatmap();
+        fastqc_seq_content_heatmap(module_element, module_key);
     });
     // Seq content - window resized
     $(window).resize(function() {
-        fastqc_seq_content_heatmap();
+        fastqc_seq_content_heatmap(module_element, module_key);
     });
 
-});
+    function plot_single_seqcontent(s_name){
+        current_single_plot = s_name;
+        var data = fastqc_seq_content[module_key][s_name];
+        var plot_data = [
+            {'name': '% T', 'data':[]},
+            {'name': '% C', 'data':[]},
+            {'name': '% A', 'data':[]},
+            {'name': '% G', 'data':[]}
+        ];
+        var bases = Object.keys(data).sort(function (a, b) {  return a - b;  });
+        for (i=0; i<bases.length; i++){
+            var d = bases[i];
+            var base = data[d]['base'].toString().split('-');
+            base = parseFloat(base[0]);
+            plot_data[0]['data'].push({x:base, y:data[d]['t'], name:data[d]['base']});
+            plot_data[1]['data'].push({x:base, y:data[d]['c'], name:data[d]['base']});
+            plot_data[2]['data'].push({x:base, y:data[d]['a'], name:data[d]['base']});
+            plot_data[3]['data'].push({x:base, y:data[d]['g'], name:data[d]['base']});
+        }
 
-function plot_single_seqcontent(s_name){
-  current_single_plot = s_name;
-  var data = fastqc_seq_content_data[s_name];
-  var plot_data = [
-    {'name': '% T', 'data':[]},
-    {'name': '% C', 'data':[]},
-    {'name': '% A', 'data':[]},
-    {'name': '% G', 'data':[]}
-  ];
-  var bases = Object.keys(data).sort(function (a, b) {  return a - b;  });
-  for (i=0; i<bases.length; i++){
-    var d = bases[i];
-    var base = data[d]['base'].toString().split('-');
-    base = parseFloat(base[0]);
-    plot_data[0]['data'].push({x:base, y:data[d]['t'], name:data[d]['base']});
-    plot_data[1]['data'].push({x:base, y:data[d]['c'], name:data[d]['base']});
-    plot_data[2]['data'].push({x:base, y:data[d]['a'], name:data[d]['base']});
-    plot_data[3]['data'].push({x:base, y:data[d]['g'], name:data[d]['base']});
-  }
+        // Create plot div if it doesn't exist, and hide overview
+        if(module_element.find('#fastqc_sequence_content_single_wrapper').length == 0) {
+            var plot_div = module_element.find('#fastqc_per_base_sequence_content_plot_div');
+            plot_div.slideUp();
+            var newplot = '<div id="fastqc_sequence_content_single_wrapper"> \
+            <div id="fastqc_sequence_content_single_controls">\
+                <button class="btn btn-primary btn-sm" id="fastqc_sequence_content_single_back">Back to overview heatmap</button> \
+                <div class="btn-group btn-group-sm"> \
+                    <button class="btn btn-default fastqc_seqcontent_single_prevnext" data-action="prev">&laquo; Prev</button> \
+                    <button class="btn btn-default fastqc_seqcontent_single_prevnext" data-action="next">Next &raquo;</button> \
+                </div>\
+            </div>\
+            <div class="hc-plot-wrapper"><div id="fastqc_sequence_content_single" class="hc-plot hc-line-plot"><small>loading..</small></div></div></div>';
+            $(newplot).insertAfter(plot_div).hide().slideDown();
+        }
 
-  // Create plot div if it doesn't exist, and hide overview
-  if($('#fastqc_sequence_content_single_wrapper').length == 0) {
-    $('#fastqc_per_base_sequence_content_plot_div').slideUp();
-    var newplot = '<div id="fastqc_sequence_content_single_wrapper"> \
-    <div id="fastqc_sequence_content_single_controls">\
-      <button class="btn btn-primary btn-sm" id="fastqc_sequence_content_single_back">Back to overview heatmap</button> \
-      <div class="btn-group btn-group-sm"> \
-        <button class="btn btn-default fastqc_seqcontent_single_prevnext" data-action="prev">&laquo; Prev</button> \
-        <button class="btn btn-default fastqc_seqcontent_single_prevnext" data-action="next">Next &raquo;</button> \
-      </div>\
-    </div>\
-    <div class="hc-plot-wrapper"><div id="fastqc_sequence_content_single" class="hc-plot hc-line-plot"><small>loading..</small></div></div></div>';
-    $(newplot).insertAfter('#fastqc_per_base_sequence_content_plot_div').hide().slideDown();
-  }
-
-  $('#fastqc_sequence_content_single').highcharts({
-    chart: {
-      type: 'line',
-      zoomType: 'x'
-    },
-    colors: ['#dc0000', '#0000dc', '#00dc00', '#404040'],
-    title: {
-      text: s_name,
-      x: 30 // fudge to center over plot area rather than whole plot
-    },
-    xAxis: {
-      title: { text: 'Position (bp)' },
-      allowDecimals: false,
-    },
-    yAxis: {
-      title: { text: '% Reads' },
-      max: 100,
-      min: 0,
-    },
-    legend: {
-      floating: true,
-      layout: 'vertical',
-      align: 'right',
-      verticalAlign: 'top',
-      y: 40
-    },
-    tooltip: {
-      backgroundColor: '#FFFFFF',
-      borderColor: '#CCCCCC',
-      formatter: function () {
-        var texts = [];
-        var bars = [];
-        var xlabel = this.x;
-        $.each(this.points, function () {
-          texts.push('<span style="display: inline-block; border-left: 3px solid '+this.color+'; padding-left:5px; margin-bottom: 2px;"></div>' + this.y.toFixed(1) + this.series.name + '</span>');
-          bars.push('<div class="progress-bar" style="width:'+this.y+'%; float:left; font-size:8px; line-height:12px; padding:0; background-color:'+this.color+';">'+this.series.name.replace('%','').trim()+'</div>');
-          if(this.point.name){ xlabel = this.point.name; }
+        module_element.find('#fastqc_sequence_content_single').highcharts({
+            chart: {
+                type: 'line',
+                zoomType: 'x'
+            },
+            colors: ['#dc0000', '#0000dc', '#00dc00', '#404040'],
+            title: {
+                text: s_name,
+                x: 30 // fudge to center over plot area rather than whole plot
+            },
+            xAxis: {
+                title: { text: 'Position (bp)' },
+                allowDecimals: false,
+            },
+            yAxis: {
+                title: { text: '% Reads' },
+                max: 100,
+                min: 0,
+            },
+            legend: {
+                floating: true,
+                layout: 'vertical',
+                align: 'right',
+                verticalAlign: 'top',
+                y: 40
+            },
+            tooltip: {
+                backgroundColor: '#FFFFFF',
+                borderColor: '#CCCCCC',
+                formatter: function () {
+                    var texts = [];
+                    var bars = [];
+                    var xlabel = this.x;
+                    $.each(this.points, function () {
+                        texts.push('<span style="display: inline-block; border-left: 3px solid '+this.color+'; padding-left:5px; margin-bottom: 2px;"></div>' + this.y.toFixed(1) + this.series.name + '</span>');
+                        bars.push('<div class="progress-bar" style="width:'+this.y+'%; float:left; font-size:8px; line-height:12px; padding:0; background-color:'+this.color+';">'+this.series.name.replace('%','').trim()+'</div>');
+                        if(this.point.name){ xlabel = this.point.name; }
+                    });
+                    return'<p style="font-weight:bold; text-decoration: underline;">Position: ' + xlabel + ' bp</p>\
+                            <p>'+texts.join('<br>')+'</p><div class="progress" style="height: 12px; width: 150px; margin:0;">'+bars.join('')+'</div>';
+                },
+                useHTML: true,
+                crosshairs: true,
+                shared: true,
+            },
+            plotOptions: {
+                series: {
+                    animation: false,
+                    marker: { enabled: false },
+                }
+            },
+            exporting: { buttons: { contextButton: {
+                menuItems: window.HCDefaults.exporting.buttons.contextButton.menuItems,
+                onclick: window.HCDefaults.exporting.buttons.contextButton.onclick
+            } } },
+            series: plot_data
         });
-        return'<p style="font-weight:bold; text-decoration: underline;">Position: ' + xlabel + ' bp</p>\
-            <p>'+texts.join('<br>')+'</p><div class="progress" style="height: 12px; width: 150px; margin:0;">'+bars.join('')+'</div>';
-      },
-			useHTML: true,
-      crosshairs: true,
-      shared: true,
-    },
-    plotOptions: {
-      series: {
-        animation: false,
-        marker: { enabled: false },
-      }
-    },
-    exporting: { buttons: { contextButton: {
-      menuItems: window.HCDefaults.exporting.buttons.contextButton.menuItems,
-      onclick: window.HCDefaults.exporting.buttons.contextButton.onclick
-    } } },
-    series: plot_data
-  });
+    }
 }
 
 
 // Find the position of the mouse cursor over the canvas
 // http://stackoverflow.com/questions/6735470/get-pixel-color-from-canvas-on-mouseover
 function findPos(obj) {
-  var curleft = 0, curtop = 0;
-  if (obj.offsetParent) {
-    do {
-      curleft += obj.offsetLeft;
-      curtop += obj.offsetTop;
-    } while (obj = obj.offsetParent);
-    return { x: curleft, y: curtop };
-  }
-  return undefined;
+    var curleft = 0, curtop = 0;
+    if (obj.offsetParent) {
+        do {
+            curleft += obj.offsetLeft;
+            curtop += obj.offsetTop;
+        } while (obj = obj.offsetParent);
+        return { x: curleft, y: curtop };
+    }
+    return undefined;
 }

--- a/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
+++ b/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
@@ -7,6 +7,7 @@
 // Set up listeners etc on page load
 $(function () {
     // Go through each FastQC module in case there are multiple
+    // #mqc-module-section-fastqc, #mqc-module-section-fastqc-1, ...
     $('.mqc-module-section[id^="mqc-module-section-fastqc"]').each(function(){
         var module_element = $(this);
         var module_key = module_element.attr('id').replace(/-/g, '_').replace('mqc_module_section_', '');
@@ -291,6 +292,7 @@ function fastqc_module(module_element, module_key) {
     // Seq Content heatmap export button
     module_element.find('#fastqc_per_base_sequence_content_export_btn').click(function(e){
         e.preventDefault();
+        // In case of repeated modules: #fastqc_per_base_sequence_content_plot, #fastqc_per_base_sequence_content_plot-1, ..
         var plot_id = module_element.find('.fastqc_per_base_sequence_content_plot').attr('id');
         // Tick only this plot in the toolbox and slide out
         $('#mqc_export_selectplots input').prop('checked', false);

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -22,6 +22,7 @@ import zipfile
 from multiqc import config
 from multiqc.plots import linegraph, bargraph
 from multiqc.modules.base_module import BaseMultiqcModule
+from multiqc.utils import report
 
 # Initialise the logger
 log = logging.getLogger(__name__)
@@ -100,7 +101,10 @@ class MultiqcModule(BaseMultiqcModule):
                     statuses[section][s_name] = status
                 except KeyError:
                     statuses[section] = {s_name: status}
-        self.intro += '<script type="text/javascript">fastqc_passfails_{} = {};</script>'.format(self.anchor.replace('-','_'), json.dumps(statuses))
+        self.intro += '''<script type="text/javascript">
+            if (!window.fastqc_passfails) fastqc_passfails = {{}};
+            fastqc_passfails[{}] = {};
+        </script>'''.format(json.dumps(self.anchor.replace('-','_')), json.dumps(statuses))
 
         # Now add each section in order
         self.read_count_plot()
@@ -451,16 +455,22 @@ class MultiqcModule(BaseMultiqcModule):
                 <div><span id="fastqc_seq_heatmap_key_g"> %G: <span>-</span></span></div>
             </div>
             <div id="fastqc_seq_heatmap_div" class="fastqc-overlay-plot">
-                <div id="fastqc_per_base_sequence_content_plot" class="hc-plot has-custom-export">
+                <div id="{id}" class="fastqc_per_base_sequence_content_plot hc-plot has-custom-export">
                     <canvas id="fastqc_seq_heatmap" height="100%" width="800px" style="width:100%;"></canvas>
                 </div>
             </div>
             <div class="clearfix"></div>
         </div>
         <script type="text/javascript">
-            fastqc_seq_content_data = {d};
-            $(function () {{ fastqc_seq_content_heatmap(); }});
-        </script>'''.format(d=json.dumps(data))
+            if (!window.fastqc_seq_content) fastqc_seq_content = {{}};
+            fastqc_seq_content[{module_key}] = {d};
+        </script>
+        '''.format(
+            # Generate unique plot ID, needed in mqc_export_selectplots
+            id=report.save_htmlid('fastqc_per_base_sequence_content_plot'),
+            module_key=json.dumps(self.anchor.replace('-', '_')),
+            d=json.dumps(data),
+        )
 
         self.add_section (
             name = 'Per Base Sequence Content',

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -103,8 +103,14 @@ class MultiqcModule(BaseMultiqcModule):
                     statuses[section] = {s_name: status}
         self.intro += '''<script type="text/javascript">
             if (!window.fastqc_passfails) fastqc_passfails = {{}};
-            fastqc_passfails[{}] = {};
-        </script>'''.format(json.dumps(self.anchor.replace('-','_')), json.dumps(statuses))
+            fastqc_passfails[{module_key}] = {data};
+
+            // Backward compatible global variables
+            window['fastqc_passfails_' + {module_key}] = fastqc_passfails[{module_key}];
+        </script>'''.format(
+            module_key=json.dumps(self.anchor.replace('-','_')),
+            data=json.dumps(statuses),
+        )
 
         # Now add each section in order
         self.read_count_plot()
@@ -464,6 +470,9 @@ class MultiqcModule(BaseMultiqcModule):
         <script type="text/javascript">
             if (!window.fastqc_seq_content) fastqc_seq_content = {{}};
             fastqc_seq_content[{module_key}] = {d};
+
+            // Backward compatible global variables
+            window['fastqc_seq_content_data'] = fastqc_seq_content[{module_key}];
         </script>
         '''.format(
             # Generate unique plot ID, needed in mqc_export_selectplots

--- a/multiqc/modules/rseqc/junction_saturation.py
+++ b/multiqc/modules/rseqc/junction_saturation.py
@@ -98,6 +98,7 @@ def plot_single():
 
     return """
     function(e){
+        // In case of repeated modules: #rseqc_junction_saturation_plot, #rseqc_junction_saturation_plot-1, ..
         var rseqc_junction_saturation_plot = $(e.currentTarget).closest('.hc-plot');
         var rseqc_junction_saturation_plot_id = rseqc_junction_saturation_plot.attr('id');
         var junction_sat_single_hint = rseqc_junction_saturation_plot.closest('.mqc-section').find('#junction_sat_single_hint');

--- a/multiqc/modules/rseqc/junction_saturation.py
+++ b/multiqc/modules/rseqc/junction_saturation.py
@@ -93,10 +93,15 @@ def parse_reports(self):
 
 def plot_single():
     """ Return JS code required for plotting a single sample
-    RSeQC plot. Attempt to make it look as much like the original as possible. """
+    RSeQC plot. Attempt to make it look as much like the original as possible.
+    Note: this code is injected by `eval(str)`, not <script type="text/javascript"> """
 
     return """
     function(e){
+        var rseqc_junction_saturation_plot = $(e.currentTarget).closest('.hc-plot');
+        var rseqc_junction_saturation_plot_id = rseqc_junction_saturation_plot.attr('id');
+        var junction_sat_single_hint = rseqc_junction_saturation_plot.closest('.mqc-section').find('#junction_sat_single_hint');
+
 
         // Get the three datasets for this sample
         var data = [
@@ -106,7 +111,7 @@ def plot_single():
         ];
         var k = 0;
         for (var i = 0; i < 3; i++) {
-            var ds = mqc_plots['rseqc_junction_saturation_plot']['datasets'][i];
+            var ds = mqc_plots[rseqc_junction_saturation_plot_id]['datasets'][i];
             for (k = 0; k < ds.length; k++){
                 if(ds[k]['name'] == this.series.name){
                     data[i]['data'] = JSON.parse(JSON.stringify(ds[k]['data']));
@@ -116,7 +121,7 @@ def plot_single():
         }
 
         // Create single plot div, and hide overview
-        var newplot = '<div id="rseqc_junction_saturation_single"> \
+        var newplot = $('<div id="rseqc_junction_saturation_single"> \
             <div id="rseqc_junction_saturation_single_controls"> \
               <button class="btn btn-primary btn-sm" id="rseqc-junction_sat_single_return"> \
                 Return to overview \
@@ -131,47 +136,47 @@ def plot_single():
                 <small>loading..</small> \
               </div> \
             </div> \
-          </div>';
-        var pwrapper = $('#rseqc_junction_saturation_plot').parent().parent();
-        $(newplot).insertAfter(pwrapper).hide().slideDown();
+          </div>');
+        var pwrapper = rseqc_junction_saturation_plot.parent().parent();
+        newplot.insertAfter(pwrapper).hide().slideDown();
         pwrapper.slideUp();
-        $('#rseqc-junction_sat_single_hint').slideUp();
+        junction_sat_single_hint.slideUp();
 
         // Listener to return to overview
-        $('#rseqc-junction_sat_single_return').click(function(e){
+        newplot.find('#rseqc-junction_sat_single_return').click(function(e){
           e.preventDefault();
-          $('#rseqc_junction_saturation_single').slideUp(function(){
+          newplot.slideUp(function(){
             $(this).remove();
           });
           pwrapper.slideDown();
-          $('#rseqc-junction_sat_single_hint').slideDown();
+          junction_sat_single_hint.slideDown();
         });
 
         // Listeners for previous / next plot
-        $('.rseqc-junction_sat_single_prevnext').click(function(e){
+        newplot.find('.rseqc-junction_sat_single_prevnext').click(function(e){
           e.preventDefault();
           if($(this).data('action') == 'prev'){
             k--;
             if(k < 0){
-              k = mqc_plots['rseqc_junction_saturation_plot']['datasets'][0].length - 1;
+              k = mqc_plots[rseqc_junction_saturation_plot_id]['datasets'][0].length - 1;
             }
           } else {
             k++;
-            if(k >= mqc_plots['rseqc_junction_saturation_plot']['datasets'][0].length){
+            if(k >= mqc_plots[rseqc_junction_saturation_plot_id]['datasets'][0].length){
               k = 0;
             }
           }
-          hc = $('#rseqc_junction_saturation_single .hc-plot').highcharts();
+          var hc = newplot.find('.hc-plot').highcharts();
           for (var i = 0; i < 3; i++) {
-              hc.series[i].setData(mqc_plots['rseqc_junction_saturation_plot']['datasets'][i][k]['data'], false);
+              hc.series[i].setData(mqc_plots[rseqc_junction_saturation_plot_id]['datasets'][i][k]['data'], false);
           }
-          var ptitle = 'RSeQC Junction Saturation: '+mqc_plots['rseqc_junction_saturation_plot']['datasets'][0][k]['name'];
+          var ptitle = 'RSeQC Junction Saturation: '+mqc_plots[rseqc_junction_saturation_plot_id]['datasets'][0][k]['name'];
           hc.setTitle({text: ptitle});
           hc.redraw({ duration: 200 });
         });
 
         // Plot the single data
-        $('#rseqc_junction_saturation_single .hc-plot').highcharts({
+        newplot.find('.hc-plot').highcharts({
           chart: {
             type: 'line',
             zoomType: 'x'


### PR DESCRIPTION
When including a FastQC section multiple times in one report, each section now shows **Per Base Sequence Content** heatmap.

When including a FastQ Screen section multiple times in one report, each section now shows **FastQ Screen** bar chart.

When including a RSeQC section multiple times in one report, **clicking Junction Saturation** in each section works.

Export toolbox also lists a separate entry for each plot.

## How

Code for passing data needed to be changed
```diff
-<script type="text/javascript">fastqc_seq_content_data = {d};</script>
+<script type="text/javascript">fastqc_seq_content[{module_key}] = {d};</script>
```

Elements with `.hc-plot` class needed to have unique IDs
```diff
-<div id="fastqc_per_base_sequence_content_plot" class="hc-plot">
+<div id="{report.save_htmlid('fastqc_per_base_sequence_content_plot')}" class="hc-plot">
```

Searching for elements needed to be limited within module
```diff
- $('.mqc-module-section[id^="mqc-module-section-fastqc"]').each(function(){
-     // Element IDs are supposed to be unique, so this finds the first one on page
-     $('#fastqc_seq_heatmap').on(function () {
-     });
- })

+ $('.mqc-module-section[id^="mqc-module-section-fastqc"]').each(function(){
+     var module_element = $(this);
+     // Element IDs are supposed to be unique, but this looks for the first one with module_element
+     module_element.find('#fastqc_seq_heatmap').on(function () {
+     });
+ })

# Note: duplicated IDs should ideally be avoided. E.g. replace `#fastqc_seq_heatmap` with class
# `.fastqc_seq_heatmap`. But I didn't want to also start changing CSS
```

Global javascript variables needed to be scoped per module
```diff
- s_height = 10;
- num_samples = 0;
- sample_names = [];
- sample_statuses = [];
- labels = [];
- c_width = 0;
- c_height = 0;
- ypos = 0;
- max_bp = 0;
- current_single_plot = undefined;
-
- $(function () {
-     draw()
- });
- function draw() {
-     c_width = 5;
- }

+ $(function () {
+     // Go through each FastQC module in case there are multiple
+     $('.mqc-module-section[id^="mqc-module-section-fastqc"]').each(function(){
+         var module_element = $(this);
+         var module_key = module_element.attr('id').replace(/-/g, '_').replace('mqc_module_section_', '');
+ 
+         var s_height = 10;
+         var num_samples = 0;
+         var sample_names = [];
+         var sample_statuses = [];
+         var labels = [];
+         var c_width = 0;
+         var c_height = 0;
+         var ypos = 0;
+         var max_bp = 0;
+         var current_single_plot = undefined;
+ 
+         draw(module_element, module_key);
+         function draw(module_element, module_key) {
+             c_width = 5;
+         }
+     });
+ });
```
