### PR TITLE
Support opening MultiQC on websites with CSP `script-src 'self'` with some sha256 exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@
     * New base image `czentye/matplotlib-minimal` reduces image size from ~200MB to ~80MB
     * Proper installation method ensures latest version of the code
     * New entrypoint allows easier command-line usage
+* Support opening MultiQC on websites with CSP `script-src 'self'` with some sha256 exceptions
+    * Plot data is no longer intertwined with javascript code so hashes stay the same
 
 #### Bug Fixes:
 * MultiQC now ignores all `.md5` files

--- a/multiqc/modules/fastq_screen/fastq_screen.py
+++ b/multiqc/modules/fastq_screen/fastq_screen.py
@@ -164,19 +164,19 @@ class MultiqcModule(BaseMultiqcModule):
 
         plot_id = report.save_htmlid('fq_screen_plot')
         html = '''<div id={plot_id} class="fq_screen_plot hc-plot"></div>
-        <script type="text/javascript">
-            if (!window.fq_screen_dict) fq_screen_dict = {{}};
-            fq_screen_dict[{plot_id}] = {dict};
-
-            // Backward compatible global variables
-            fq_screen_data = fq_screen_dict[{plot_id}].data;
-            fq_screen_categories = fq_screen_dict[{plot_id}].categories;
-        </script>'''.format(
+        <script type="application/json" class="fq_screen_dict">{dict}</script>
+        '''.format(
             plot_id=json.dumps(plot_id),
-            dict=json.dumps({ 'data': data, 'categories': categories }),
+            dict=json.dumps({ 'plot_id': plot_id, 'data': data, 'categories': categories }),
         )
 
         html += '''<script type="text/javascript">
+            fq_screen_dict = { }; // { <plot_id>: data, categories }
+            $('.fq_screen_dict').each(function (i, elem) {
+                var dict = JSON.parse(elem.innerHTML);
+                fq_screen_dict[dict.plot_id] = dict;
+            });
+
             $(function () {
                 // In case of repeated modules: #fq_screen_plot, #fq_screen_plot-1, ..
                 $(".fq_screen_plot").each(function () {

--- a/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
+++ b/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
@@ -4,6 +4,16 @@
 // Per Base Sequence Content
 ///////////////
 
+// Global vars
+fastqc_passfails = {}; // { <module>: { <section>: { <sample>: { data } } }
+
+function load_fastqc_passfails() {
+    $('.fastqc_passfails').each(function (i, elem) {
+        var key_value = JSON.parse(elem.innerHTML);
+        fastqc_passfails[key_value[0]] = key_value[1];
+    });
+}
+
 // Set up listeners etc on page load
 $(function () {
     // Go through each FastQC module in case there are multiple

--- a/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
+++ b/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
@@ -6,6 +6,7 @@
 
 // Global vars
 fastqc_passfails = {}; // { <module>: { <section>: { <sample>: { data } } }
+fastqc_seq_content = {}; // { <module>: { <sample>: data } }
 
 function load_fastqc_passfails() {
     $('.fastqc_passfails').each(function (i, elem) {
@@ -14,8 +15,17 @@ function load_fastqc_passfails() {
     });
 }
 
+function load_fastqc_seq_content() {
+    $('.fastqc_seq_content').each(function (i, elem) {
+        var key_value = JSON.parse(elem.innerHTML);
+        fastqc_seq_content[key_value[0]] = key_value[1];
+    });
+}
+
 // Set up listeners etc on page load
 $(function () {
+    load_fastqc_seq_content();
+
     // Go through each FastQC module in case there are multiple
     // #mqc-module-section-fastqc, #mqc-module-section-fastqc-1, ...
     $('.mqc-module-section[id^="mqc-module-section-fastqc"]').each(function(){

--- a/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
+++ b/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
@@ -13,12 +13,20 @@ function load_fastqc_passfails() {
         var key_value = JSON.parse(elem.innerHTML);
         fastqc_passfails[key_value[0]] = key_value[1];
     });
+
+    // Backward compatible global variables
+    $.each(fastqc_passfails, function (key, value) {
+        window['fastqc_passfails_' + key] = value;
+    });
 }
 
 function load_fastqc_seq_content() {
     $('.fastqc_seq_content').each(function (i, elem) {
         var key_value = JSON.parse(elem.innerHTML);
         fastqc_seq_content[key_value[0]] = key_value[1];
+
+        // Backward compatible global variable
+        window['fastqc_seq_content_data'] = key_value[1];
     });
 }
 

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -467,6 +467,9 @@ class MultiqcModule(BaseMultiqcModule):
             d=json.dumps([self.anchor.replace('-', '_'), data]),
         )
 
+        # Immediately set backward compatible global variable
+        html += '<script type="text/javascript">load_fastqc_seq_content();</script>'
+
         self.add_section (
             name = 'Per Base Sequence Content',
             anchor = 'fastqc_per_base_sequence_content',

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -460,18 +460,11 @@ class MultiqcModule(BaseMultiqcModule):
             </div>
             <div class="clearfix"></div>
         </div>
-        <script type="text/javascript">
-            if (!window.fastqc_seq_content) fastqc_seq_content = {{}};
-            fastqc_seq_content[{module_key}] = {d};
-
-            // Backward compatible global variables
-            window['fastqc_seq_content_data'] = fastqc_seq_content[{module_key}];
-        </script>
+        <script type="application/json" class="fastqc_seq_content">{d}</script>
         '''.format(
             # Generate unique plot ID, needed in mqc_export_selectplots
             id=report.save_htmlid('fastqc_per_base_sequence_content_plot'),
-            module_key=json.dumps(self.anchor.replace('-', '_')),
-            d=json.dumps(data),
+            d=json.dumps([self.anchor.replace('-', '_'), data]),
         )
 
         self.add_section (

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -101,16 +101,9 @@ class MultiqcModule(BaseMultiqcModule):
                     statuses[section][s_name] = status
                 except KeyError:
                     statuses[section] = {s_name: status}
-        self.intro += '''<script type="text/javascript">
-            if (!window.fastqc_passfails) fastqc_passfails = {{}};
-            fastqc_passfails[{module_key}] = {data};
+        self.intro += '<script type="application/json" class="fastqc_passfails">{}</script>'.format(json.dumps([self.anchor.replace('-', '_'), statuses ]))
 
-            // Backward compatible global variables
-            window['fastqc_passfails_' + {module_key}] = fastqc_passfails[{module_key}];
-        </script>'''.format(
-            module_key=json.dumps(self.anchor.replace('-','_')),
-            data=json.dumps(statuses),
-        )
+        self.intro += '<script type="text/javascript">load_fastqc_passfails();</script>'
 
         # Now add each section in order
         self.read_count_plot()

--- a/multiqc/templates/default/assets/js/multiqc_plotting.js
+++ b/multiqc/templates/default/assets/js/multiqc_plotting.js
@@ -65,7 +65,7 @@ $(function () {
   $('.hc-plot.not_rendered:visible:not(.gt_max_num_ds)').each(function(){
     var target = $(this).attr('id');
     // Only one point per dataset, so multiply limit by arbitrary number.
-    var max_num = num_datasets_plot_limit * 50;
+    var max_num = mqc_config['num_datasets_plot_limit'] * 50;
     // Deferring each plot call prevents browser from locking up
     setTimeout(function(){
         plot_graph(target, undefined, max_num);

--- a/multiqc/templates/default/assets/js/multiqc_toolbox.js
+++ b/multiqc/templates/default/assets/js/multiqc_toolbox.js
@@ -25,9 +25,9 @@ $(function () {
     if(j == 0){
       apply_mqc_renamesamples();
     } else {
-      for(i=0; i<mqc_sample_names_rename.length; i++){
-        var ft = mqc_sample_names_rename[i][0];
-        var tt = mqc_sample_names_rename[i][j];
+      for(i=0; i<mqc_config['sample_names_rename'].length; i++){
+        var ft = mqc_config['sample_names_rename'][i][0];
+        var tt = mqc_config['sample_names_rename'][i][j];
         $('#mqc_renamesamples_filters').append('<li class="mqc_sname_switches_li"> \
           <input class="f_text from_text" value="'+ft+'" /><small class="glyphicon glyphicon-chevron-right"></small><input class="f_text to_text" value="'+tt+'" /> \
           <button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button> \
@@ -57,7 +57,7 @@ $(function () {
   $(document).on('mqc_config_loaded', function(e){
     $('.hc-plot').each(function(){
       var target = $(this).attr('id');
-      plot_graph(target, undefined, num_datasets_plot_limit);
+      plot_graph(target, undefined, mqc_config['num_datasets_plot_limit']);
     });
   });
 

--- a/multiqc/templates/default/head.html
+++ b/multiqc/templates/default/head.html
@@ -16,14 +16,26 @@ page contents, it's machine-readable tags for browsers and search engines.
 <title>{{ config.title + ': ' if config.title != None }}MultiQC Report</title>
 
 <!-- JSON plot data -->
-<script type="text/javascript">
-mqc_compressed_plotdata = '{{ report.plot_compressed_json }}';
-num_datasets_plot_limit = {{ config.num_datasets_plot_limit}};
-mqc_sample_names_rename = {{ config.sample_names_rename | tojson }};
-</script>
+<script type="text/plain" id="mqc_compressed_plotdata">{{ report.plot_compressed_json }}</script>
 
+<script type="application/json" id="mqc_config">{{
+{
+    "num_datasets_plot_limit": config.num_datasets_plot_limit,
+    "sample_names_rename": config.sample_names_rename,
+    "decimalPoint_format": config.decimalPoint_format,
+    "thousandsSep_format": config.thousandsSep_format,
+} | tojson
+}}</script>
+
+<!-- Instead of saving data directly into variables in a normal <script>, data is separated into
+     above non-executed script blocks. This way, potential Content Security Policy restrictions
+     only apply to static script blocks, which can be added as sha256 exceptions.
+
+     As a precaution the script is wrapped in raw block to remind developers that data should
+     not be injected directly into it. -->
+{% raw %}
 <script type="text/javascript">
-mqc_config = {}
-{% if config.decimalPoint_format is not none %}mqc_config['decimalPoint_format'] = '{{ config.decimalPoint_format }}'; {% endif %}
-{% if config.thousandsSep_format is not none %}mqc_config['thousandsSep_format'] = '{{ config.thousandsSep_format }}'; {% endif %}
+mqc_compressed_plotdata = document.getElementById('mqc_compressed_plotdata').innerHTML;
+mqc_config = JSON.parse(document.getElementById('mqc_config').innerHTML);
 </script>
+{% endraw %}

--- a/multiqc/templates/default/head.html
+++ b/multiqc/templates/default/head.html
@@ -21,3 +21,9 @@ mqc_compressed_plotdata = '{{ report.plot_compressed_json }}';
 num_datasets_plot_limit = {{ config.num_datasets_plot_limit}};
 mqc_sample_names_rename = {{ config.sample_names_rename | tojson }};
 </script>
+
+<script type="text/javascript">
+mqc_config = {}
+{% if config.decimalPoint_format is not none %}mqc_config['decimalPoint_format'] = '{{ config.decimalPoint_format }}'; {% endif %}
+{% if config.thousandsSep_format is not none %}mqc_config['thousandsSep_format'] = '{{ config.thousandsSep_format }}'; {% endif %}
+</script>

--- a/multiqc/templates/default/head.html
+++ b/multiqc/templates/default/head.html
@@ -37,5 +37,9 @@ page contents, it's machine-readable tags for browsers and search engines.
 <script type="text/javascript">
 mqc_compressed_plotdata = document.getElementById('mqc_compressed_plotdata').innerHTML;
 mqc_config = JSON.parse(document.getElementById('mqc_config').innerHTML);
+
+// Backward compatible global variables
+num_datasets_plot_limit = mqc_config['num_datasets_plot_limit'];
+mqc_sample_names_rename = mqc_config['sample_names_rename'];
 </script>
 {% endraw %}

--- a/multiqc/templates/default/includes.html
+++ b/multiqc/templates/default/includes.html
@@ -66,8 +66,3 @@ it prints the contents of these files into the report.
 <script type="text/javascript">{{ include_file( js_href, None ) }}</script>
 {% endif %}
 {%- endfor %}{% endif %}{% endfor %}
-<script type="text/javascript">
-mqc_config = {}
-{% if config.decimalPoint_format is not none %}mqc_config['decimalPoint_format'] = '{{ config.decimalPoint_format }}'; {% endif %}
-{% if config.thousandsSep_format is not none %}mqc_config['thousandsSep_format'] = '{{ config.thousandsSep_format }}'; {% endif %}
-</script>

--- a/multiqc/templates/default_dev/includes.html
+++ b/multiqc/templates/default_dev/includes.html
@@ -54,8 +54,3 @@ it prints the contents of these files into the report.
 {%- for m in report.modules_output %}{% if m.js and m.js|length > 0 -%}{% for js_href in m.js.keys() %}
 <script type="text/javascript" src="{{ js_href }}"></script>
 {%- endfor %}{% endif %}{% endfor %}
-<script type="text/javascript">
-mqc_config = {}
-{% if config.decimalPoint_format is not none %}mqc_config['decimalPoint_format'] = '{{ config.decimalPoint_format }}'; {% endif %}
-{% if config.thousandsSep_format is not none %}mqc_config['thousandsSep_format'] = '{{ config.thousandsSep_format }}'; {% endif %}
-</script>


### PR DESCRIPTION
So far MultiQC reports could not be opened on websites that use [Content-Security-Policy](https://content-security-policy.com/) header to limit XSS attacks (it would require `script-src 'unsafe-inline'`).

With this pullrequest, data passed into html is separated from javascript. This allows using CSP with hash exception for each script (because hash doesn't change with data anymore)
`script-src 'self' 'sha256-<script>' 'sha256-<script>' ...;`

It isn't a perfect solution, as server admins using CSP will have to update exceptions with MultiQC releases, but at least they can avoid `'unsafe-inline'`.

## List of CSP hash codes for this MultiQC version

```
Content-Security-Policy:
    script-src 
        'self'
        'sha256-X9boLn1Jzgn6VfdR/mbleypCzQB7wVaQ45tYrsWmfBQ=' // load mqc_compressed_plotdata and mqc_config
        'sha256-+F66a8s8ponoNnBnP06kgZ4LvQ6IBedFeTJHpTbA0O0=' // load_fastqc_passfails();
        'sha256-hBQTjaW1/EOhnTxMz3aTwQHziBXZnlSP6On3OlSNP0A=' // load_fastqc_seq_content();
        'sha256-pMsBH3T9O1Z2ybOWP9nXEnBjBiYNE7W0JnFTJc2udmw=' // fastq screen inline script

        'sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=' // jquery-3.1.1.min.js
        'sha256-iWO8z1sbOFlW9jqHm6PDldXb2wCcqo3gBNPZxg/TBBs=' // jquery-ui.min.js
        'sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=' // bootstrap.min.js
        'sha256-QwUrND/LJhYUBcYRAAxtMNWjZhZI+Yr8N7fpvHSFd4E=' // highcharts.js
        'sha256-X5AUZ+9MCHrVWj/x7N3Rkc/02lN9YB7fEx9RODM7A+k=' // highcharts.heatmap.js
        'sha256-+9tTm/2PzXj/LVTpB+PDvRvk7tG4QGM5YZIKs4DE45o=' // highcharts.exporting.js
        'sha256-Vndz/rd9+SJEYoVVpV/BqYrULpr5CA+pwbE6rbynp/0=' // highcharts.offline-exporting.js
        'sha256-qRzmKGpTQ9kQfjgKtYTcIxkIAwipJOcF3c6psri9FAc=' // highcharts.export-csv.js
        'sha256-AhtCowp6HzQCEXZP0Bdbk1Jg9PEYtx8/jZkfHJgXY2c=' // jquery.tablesorter.min.js
        'sha256-mYqjlBuTYmeoEFTjuPCrwns2stAp2HOJyXR5X2xjP70=' // clipboard.min.js
        'sha256-FPJJt8nA+xL4RU6/gsriA8p8xAeLGatoyTjldvQKGdE=' // FileSaver.min.js
        'sha256-nRoO8HoupfqozUr7YKBRgHXmdx40Hl/04OSBzv7e7L8=' // lz-string.min.js
        'sha256-v69SxdPeknzXy0hkSHL/SrchLvO8QDQS4N7V50xE0Ks=' // jquery.toast.min.js
        'sha256-7gUXukWB8g8TYIxnHrzoQrukADhWL1n8vcdPVzDvf9o=' // multiqc.js
        'sha256-fVOaB1wl1OdyqI8PMCikOOEYHxPqQzQPtst8jVEUrfs=' // multiqc_tables.js
        'sha256-+pOrbPU8yLRc3gIYFSyzUfvh3zDWjv4P+WgZr3tm8yg=' // multiqc_plotting.js
        'sha256-8kPZc83fQr/qzo5ISaYAcLl4M5meLuuTzHFVRGb4GhU=' // multiqc_mpl.js
        'sha256-1pWjCVoi5AoQvT52zb72qGCpIpfJzlc9trKcbcarXUY=' // multiqc_toolbox.js
        'sha256-HIibatV2ktI1Wt/XhEcVzQJTBSw1f51Enxf7JVe5v68=' // multiqc_fastqc.js

        'sha256-bXJ/DLuHU3+9ybEepMTgDM965n8Cp2jD7JEJZtsWxGc=' // multiqc_tables.js version with CSP without multi-sections
        'sha256-AzuP74MO1xsRljs7mAfk56aLW7JT0TNECViHCvfj7c8=' // multiqc_fastqc.js version with CSP without multi-sections
        'sha256-6Iyez8LRQbIQe12+IHNW66k9OJvzlLF1yPb2gK11T5o=' // fastq screen inline script version with CSP without multi-sections
    ;
```
